### PR TITLE
Use Chrome manifest JSON schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,11 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib"
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/manifest.json"
+            ],
+            "url": "http://json.schemastore.org/chrome-manifest"
+        }
+    ]
 }


### PR DESCRIPTION
This PR proposes using Chrome manifest JSON schema. What this means is, whenever `manifest.json` is being edited in the project, suggestions are given from `http://json.schemastore.org/chrome-manifest`.