### PR TITLE
Update minimum version of webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ts-jest": "^27.0.5",
     "ts-loader": "^8.0.0",
     "typescript": "^4.4.3 ",
-    "webpack": "^5.0.0",
+    "webpack": "^5.61.0",
     "webpack-cli": "^4.0.0",
     "webpack-merge": "^5.0.0"
   }


### PR DESCRIPTION
When using latest node, webpack produces an error,

Error: error:0308010C:digital envelope routines::unsupported

https://github.com/webpack/webpack/issues/14532

This is due to the webpack version being 5.53.0 when running npm install.  The error is fixed in 5.61.0 by the following merged pull request,

https://github.com/webpack/webpack/pull/14584

https://github.com/webpack/webpack/releases/tag/v5.61.0

When I set 5.61.0 as the minimum I now get 5.72.0 version which is latest. Build completes without error.