### PR TITLE
fix: enable tree-shake using 'module':'es6'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "rimraf": "^3.0.2 ",
         "ts-jest": "^27.0.5",
         "ts-loader": "^8.0.0",
-        "typescript": "^4.4.3 ",
+        "typescript": "^5.0.4",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.0.0",
         "webpack-merge": "^5.0.0"
@@ -4712,16 +4712,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/universalify": {
@@ -8981,9 +8981,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "rimraf": "^3.0.2 ",
     "ts-jest": "^27.0.5",
     "ts-loader": "^8.0.0",
-    "typescript": "^4.4.3 ",
+    "typescript": "^5.0.4",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.0.0",
     "webpack-merge": "^5.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
     "compilerOptions": {
         "strict": true,
-        "module": "commonjs",
         "target": "es6",
+        "moduleResolution": "bundler",
+        "module": "ES6",
         "esModuleInterop": true,
         "sourceMap": false,
         "rootDir": "src",


### PR DESCRIPTION
#56 
- allow tree shake
- bump typescript so can use    `"moduleResolution": "bundler"`